### PR TITLE
feature/timeout

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -214,8 +214,9 @@ class Scanner(object):
             verify = True
 
         try:
+            # wait 61 seconds before timing out
             req = requests.request(method, url, data=payload, files=files,
-                                   verify=verify, headers=headers)
+                                   verify=verify, headers=headers, timeout=61)
 
             if not download and req.text:
                 self.res = req.json()


### PR DESCRIPTION
Set the timeout time to 61 seconds to (hopefully) solve the issue of celery losing the connection and giving up. Untested because of the set up of Blueflow, but I will revert my changes if it does not work or needs to be modified.